### PR TITLE
feat: add Autopilot device management

### DIFF
--- a/src-tauri/src/graph.rs
+++ b/src-tauri/src/graph.rs
@@ -4,6 +4,7 @@ use std::time::{Duration, Instant};
 use thiserror::Error;
 
 const GRAPH_BASE: &str = "https://graph.microsoft.com/beta/deviceManagement";
+const GRAPH_BETA: &str = "https://graph.microsoft.com/beta";
 
 #[derive(Debug, Error)]
 pub enum AppError {
@@ -59,6 +60,74 @@ pub struct DeviceInfo {
     pub last_sync_date_time: Option<String>,
     #[serde(default)]
     pub management_state: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct AutopilotDevice {
+    pub id: String,
+    #[serde(default)]
+    pub group_tag: Option<String>,
+    #[serde(default)]
+    pub serial_number: Option<String>,
+    #[serde(default)]
+    pub product_key: Option<String>,
+    #[serde(default)]
+    pub manufacturer: Option<String>,
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub enrollment_state: Option<String>,
+    #[serde(default)]
+    pub last_contacted_date_time: Option<String>,
+    #[serde(default)]
+    pub addressable_user_name: Option<String>,
+    #[serde(default)]
+    pub user_principal_name: Option<String>,
+    #[serde(default)]
+    pub managed_device_id: Option<String>,
+    #[serde(default)]
+    pub azure_active_directory_device_id: Option<String>,
+    #[serde(default)]
+    pub azure_ad_device_id: Option<String>,
+    #[serde(default)]
+    pub display_name: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct AutopilotImportEntry {
+    #[serde(default)]
+    pub serial_number: Option<String>,
+    pub hardware_identifier: String,
+    #[serde(default)]
+    pub product_key: Option<String>,
+    #[serde(default)]
+    pub group_tag: Option<String>,
+    #[serde(default)]
+    pub assigned_user_principal_name: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct AutopilotImportResult {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub serial_number: Option<String>,
+    #[serde(default)]
+    pub state: Option<AutopilotImportState>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct AutopilotImportState {
+    #[serde(default)]
+    pub device_import_status: Option<String>,
+    #[serde(default)]
+    pub device_error_code: Option<i64>,
+    #[serde(default)]
+    pub device_error_name: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -199,6 +268,103 @@ impl<'a> GraphClient<'a> {
         validate_id(device_id, "device_id")?;
         let url = format!("{}/managedDevices/{}/rebootNow", GRAPH_BASE, device_id);
         self.post_action(&url).await
+    }
+
+    pub async fn get_autopilot_devices(&self) -> Result<Vec<AutopilotDevice>, AppError> {
+        let initial_url = format!(
+            "{}/windowsAutopilotDeviceIdentities?$top=200",
+            GRAPH_BASE
+        );
+        self.get_all_pages::<AutopilotDevice>(&initial_url).await
+    }
+
+    pub async fn delete_autopilot_device(&self, device_id: &str) -> Result<(), AppError> {
+        validate_id(device_id, "autopilot_device_id")?;
+        let url = format!(
+            "{}/windowsAutopilotDeviceIdentities/{}",
+            GRAPH_BASE, device_id
+        );
+
+        let resp = self.request_with_retry(|| {
+            self.client
+                .delete(&url)
+                .bearer_auth(&self.access_token)
+        }).await?;
+
+        if !resp.status().is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(AppError::Graph(format!("Delete failed: {}", body)));
+        }
+        Ok(())
+    }
+
+    pub async fn update_autopilot_group_tag(
+        &self,
+        device_id: &str,
+        group_tag: &str,
+    ) -> Result<(), AppError> {
+        validate_id(device_id, "autopilot_device_id")?;
+        let url = format!(
+            "{}/windowsAutopilotDeviceIdentities/{}/updateDeviceProperties",
+            GRAPH_BASE, device_id
+        );
+
+        let body = serde_json::json!({
+            "groupTag": group_tag
+        });
+
+        let resp = self
+            .client
+            .post(&url)
+            .bearer_auth(&self.access_token)
+            .json(&body)
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let resp_body = resp.text().await.unwrap_or_default();
+            return Err(AppError::Graph(format!("Update group tag failed: {}", resp_body)));
+        }
+        Ok(())
+    }
+
+    pub async fn import_autopilot_devices(
+        &self,
+        entries: Vec<AutopilotImportEntry>,
+    ) -> Result<Vec<AutopilotImportResult>, AppError> {
+        // Import each device individually since the batch endpoint has limitations
+        let mut results = Vec::new();
+        for entry in &entries {
+            let url = format!(
+                "{}/deviceManagement/importedWindowsAutopilotDeviceIdentities",
+                GRAPH_BETA
+            );
+
+            let resp = self
+                .client
+                .post(&url)
+                .bearer_auth(&self.access_token)
+                .json(&entry)
+                .send()
+                .await?;
+
+            if resp.status().is_success() {
+                let result: AutopilotImportResult = resp.json().await?;
+                results.push(result);
+            } else {
+                let body = resp.text().await.unwrap_or_default();
+                results.push(AutopilotImportResult {
+                    id: String::new(),
+                    serial_number: entry.serial_number.clone(),
+                    state: Some(AutopilotImportState {
+                        device_import_status: Some("error".to_string()),
+                        device_error_code: None,
+                        device_error_name: Some(body),
+                    }),
+                });
+            }
+        }
+        Ok(results)
     }
 
     pub async fn run_remediation(&self, script_id: &str, device_id: &str) -> Result<(), AppError> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,6 @@
 mod graph;
 
-use graph::{acquire_token, AppError, AppState, CachedToken, Credentials, DeviceInfo, GraphClient};
+use graph::{acquire_token, AppError, AppState, AutopilotDevice, AutopilotImportEntry, AutopilotImportResult, CachedToken, Credentials, DeviceInfo, GraphClient};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
@@ -121,6 +121,41 @@ async fn run_remediation(
 }
 
 #[tauri::command]
+async fn get_autopilot_devices(state: State<'_>) -> Result<Vec<AutopilotDevice>, AppError> {
+    let (http_client, token) = get_client_and_token(&state).await?;
+    let client = GraphClient::new(&http_client, token);
+    client.get_autopilot_devices().await
+}
+
+#[tauri::command]
+async fn delete_autopilot_device(state: State<'_>, device_id: String) -> Result<(), AppError> {
+    let (http_client, token) = get_client_and_token(&state).await?;
+    let client = GraphClient::new(&http_client, token);
+    client.delete_autopilot_device(&device_id).await
+}
+
+#[tauri::command]
+async fn update_autopilot_group_tag(
+    state: State<'_>,
+    device_id: String,
+    group_tag: String,
+) -> Result<(), AppError> {
+    let (http_client, token) = get_client_and_token(&state).await?;
+    let client = GraphClient::new(&http_client, token);
+    client.update_autopilot_group_tag(&device_id, &group_tag).await
+}
+
+#[tauri::command]
+async fn import_autopilot_devices(
+    state: State<'_>,
+    entries: Vec<AutopilotImportEntry>,
+) -> Result<Vec<AutopilotImportResult>, AppError> {
+    let (http_client, token) = get_client_and_token(&state).await?;
+    let client = GraphClient::new(&http_client, token);
+    client.import_autopilot_devices(entries).await
+}
+
+#[tauri::command]
 fn save_secret(account: String, secret: String) -> Result<(), AppError> {
     let entry = keyring::Entry::new(KEYRING_SERVICE, &account)
         .map_err(|e| AppError::Keyring(e.to_string()))?;
@@ -164,6 +199,10 @@ pub fn run() {
             sync_device,
             restart_device,
             run_remediation,
+            get_autopilot_devices,
+            delete_autopilot_device,
+            update_autopilot_group_tag,
+            import_autopilot_devices,
             save_secret,
             load_secret,
             delete_secret,

--- a/src/App.css
+++ b/src/App.css
@@ -1437,6 +1437,101 @@ button {
   color: #86868b;
 }
 
+/* View Switcher */
+.view-switcher {
+  display: flex;
+  gap: 0;
+  background: #f0f0f5;
+  border: 1px solid #d2d2d7;
+  border-radius: 8px;
+  padding: 2px;
+  margin-right: 4px;
+}
+
+.view-switch-btn {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 12px;
+  border: none;
+  background: transparent;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 500;
+  color: #86868b;
+  transition: all 0.15s ease;
+}
+
+.view-switch-btn:hover {
+  color: #1d1d1f;
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.view-switch-btn.active {
+  color: #fff;
+  background: #0071e3;
+}
+
+/* Autopilot View */
+.autopilot-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  gap: 12px;
+}
+
+.autopilot-sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 8px 12px;
+  border-bottom: 1px solid #e8e8ed;
+  gap: 8px;
+}
+
+.group-tag-icon {
+  color: #86868b;
+  flex-shrink: 0;
+}
+
+.group-tag-display {
+  cursor: pointer;
+  border-bottom: 1px dashed transparent;
+  transition: all 0.15s ease;
+  padding-bottom: 1px;
+}
+
+.group-tag-display:hover {
+  border-bottom-color: #0071e3;
+  color: #0071e3;
+}
+
+.group-tag-edit {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.group-tag-edit input {
+  padding: 3px 8px;
+  border: 1px solid #0071e3;
+  border-radius: 4px;
+  font-size: 13px;
+  outline: none;
+  min-width: 150px;
+}
+
+.toolbar-btn-danger {
+  color: #ff3b30 !important;
+}
+
+.toolbar-btn-danger:hover {
+  background: rgba(255, 59, 48, 0.06) !important;
+}
+
 /* Dark mode */
 @media (prefers-color-scheme: dark) {
   :root {
@@ -1688,5 +1783,56 @@ button {
   .lists-header-btn.active {
     color: #5ac8fa;
     background: rgba(90, 200, 250, 0.15);
+  }
+
+  .view-switcher {
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+  }
+
+  .view-switch-btn {
+    color: #98989d;
+  }
+
+  .view-switch-btn:hover {
+    color: #e5e5ea;
+    background: rgba(255, 255, 255, 0.06);
+  }
+
+  .view-switch-btn.active {
+    color: #fff;
+    background: #0a84ff;
+  }
+
+  .autopilot-sidebar-header {
+    border-bottom-color: rgba(255, 255, 255, 0.08);
+  }
+
+  .group-tag-icon {
+    color: #98989d;
+  }
+
+  .group-tag-display {
+    color: #e5e5ea;
+    border-bottom-color: rgba(255, 255, 255, 0.15);
+  }
+
+  .group-tag-display:hover {
+    border-bottom-color: #5ac8fa;
+    color: #5ac8fa;
+  }
+
+  .group-tag-edit input {
+    background: rgba(255, 255, 255, 0.08);
+    border-color: #0a84ff;
+    color: #f5f5f7;
+  }
+
+  .toolbar-btn-danger {
+    color: #ff453a !important;
+  }
+
+  .toolbar-btn-danger:hover {
+    background: rgba(255, 69, 58, 0.08) !important;
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,7 @@ import type { DeviceInfo, RemediationScript, DeviceList, DeviceListFolder, Toast
 import { loadSavedLists, saveLists, loadSavedFolders, saveFolders, loadSavedScripts, saveScripts } from "./hooks/useLocalStorage";
 import { normalizeOs, isWindows, getOsIcon, extractOu, formatDate } from "./utils/device";
 import DeviceItem from "./components/DeviceItem";
+import AutopilotView from "./components/AutopilotView";
 
 
 function App() {
@@ -70,6 +71,7 @@ function App() {
   const [renamingFolder, setRenamingFolder] = useState<{ id: string; name: string } | null>(null);
   const [checkedLists, setCheckedLists] = useState<Set<string>>(new Set());
   const [reorderMode, setReorderMode] = useState(false);
+  const [activeView, setActiveView] = useState<"devices" | "autopilot">("devices");
 
   const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -1055,13 +1057,31 @@ function App() {
       <div className="header">
         <h1>Intune Device Manager</h1>
         <div className="header-actions">
-          <button
-            className="btn-secondary btn-small"
-            onClick={() => loadDevices()}
-            disabled={loading}
-          >
-            {loading ? <><span className="spinner" />Refreshing...</> : "Refresh"}
-          </button>
+          <div className="view-switcher">
+            <button
+              className={`view-switch-btn${activeView === "devices" ? " active" : ""}`}
+              onClick={() => setActiveView("devices")}
+            >
+              <Icon path={mdiDevices} size={0.6} />
+              Devices
+            </button>
+            <button
+              className={`view-switch-btn${activeView === "autopilot" ? " active" : ""}`}
+              onClick={() => setActiveView("autopilot")}
+            >
+              <Icon path={mdiSync} size={0.6} />
+              Autopilot
+            </button>
+          </div>
+          {activeView === "devices" && (
+            <button
+              className="btn-secondary btn-small"
+              onClick={() => loadDevices()}
+              disabled={loading}
+            >
+              {loading ? <><span className="spinner" />Refreshing...</> : "Refresh"}
+            </button>
+          )}
           <button
             className="btn-secondary btn-small btn-icon"
             onClick={() => setShowSettings(true)}
@@ -1075,6 +1095,7 @@ function App() {
         </div>
       </div>
 
+      {activeView === "devices" && (
       <div className="tab-bar">
         {OS_TABS.map((tab) => (
           <button
@@ -1090,8 +1111,13 @@ function App() {
           </button>
         ))}
       </div>
+      )}
 
-      {checkedDevices.size > 0 && (
+      {activeView === "autopilot" && (
+        <AutopilotView showToast={showToast} updateProgress={updateProgress} />
+      )}
+
+      {activeView === "devices" && checkedDevices.size > 0 && (
         <div className="bulk-bar">
           <div className="bulk-left">
             <button className="bulk-close" onClick={clearChecked} title="Clear selection">
@@ -1187,6 +1213,7 @@ function App() {
         </div>
       )}
 
+      {activeView === "devices" && (
       <div className="main-content">
         <div className="sidebar">
           {/* Custom lists */}
@@ -1483,6 +1510,7 @@ function App() {
           )}
         </div>
       </div>
+      )}
 
       {/* Remediation modal */}
       {showRemediation && (

--- a/src/components/AutopilotView.tsx
+++ b/src/components/AutopilotView.tsx
@@ -1,0 +1,667 @@
+import { useState, useCallback, useMemo } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { open, confirm } from "@tauri-apps/plugin-dialog";
+import { readTextFile } from "@tauri-apps/plugin-fs";
+import Icon from "@mdi/react";
+import {
+  mdiDelete,
+  mdiImport,
+  mdiTag,
+  mdiChevronDown,
+  mdiChevronRight,
+  mdiClose,
+  mdiCheckboxBlankOutline,
+  mdiCheckboxMarked,
+  mdiSelectAll,
+  mdiSelectionOff,
+  mdiLaptop,
+} from "@mdi/js";
+import type { AutopilotDevice, AutopilotImportEntry, AutopilotImportResult, Toast } from "../types";
+import { formatDate } from "../utils/device";
+
+interface AutopilotViewProps {
+  showToast: (message: string, type: Toast["type"], progress?: { current: number; total: number }) => void;
+  updateProgress: (label: string, current: number, total: number) => void;
+}
+
+function AutopilotView({ showToast, updateProgress }: AutopilotViewProps) {
+  const [autopilotDevices, setAutopilotDevices] = useState<AutopilotDevice[]>([]);
+  const [selectedDevice, setSelectedDevice] = useState<AutopilotDevice | null>(null);
+  const [checkedDevices, setCheckedDevices] = useState<Set<string>>(new Set());
+  const [searchQuery, setSearchQuery] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [editingGroupTag, setEditingGroupTag] = useState<{ id: string; value: string } | null>(null);
+  const [bulkGroupTag, setBulkGroupTag] = useState<string | null>(null);
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
+
+  const loadAutopilotDevices = useCallback(async () => {
+    setLoading(true);
+    try {
+      const result = await invoke<AutopilotDevice[]>("get_autopilot_devices");
+      setAutopilotDevices(result);
+      setLoaded(true);
+    } catch (e) {
+      showToast(`Failed to load Autopilot devices: ${e}`, "error");
+    } finally {
+      setLoading(false);
+    }
+  }, [showToast]);
+
+  // Load on first render
+  if (!loaded && !loading) {
+    loadAutopilotDevices();
+  }
+
+  const filteredDevices = useMemo(() => {
+    if (!searchQuery) return autopilotDevices;
+    const terms = searchQuery
+      .split(",")
+      .map((t) => t.trim().toLowerCase())
+      .filter((t) => t.length > 0);
+    if (terms.length === 0) return autopilotDevices;
+    return autopilotDevices.filter((d) => {
+      const serial = (d.serialNumber || "").toLowerCase();
+      const model = (d.model || "").toLowerCase();
+      const manufacturer = (d.manufacturer || "").toLowerCase();
+      const tag = (d.groupTag || "").toLowerCase();
+      const user = (d.userPrincipalName || d.addressableUserName || "").toLowerCase();
+      const display = (d.displayName || "").toLowerCase();
+      return terms.some(
+        (q) =>
+          serial.includes(q) ||
+          model.includes(q) ||
+          manufacturer.includes(q) ||
+          tag.includes(q) ||
+          user.includes(q) ||
+          display.includes(q)
+      );
+    });
+  }, [autopilotDevices, searchQuery]);
+
+  const sortedDevices = useMemo(
+    () =>
+      [...filteredDevices].sort((a, b) =>
+        (a.serialNumber || "").localeCompare(b.serialNumber || "", undefined, { sensitivity: "base" })
+      ),
+    [filteredDevices]
+  );
+
+  // Group by group tag
+  const groupedDevices = useMemo(() => {
+    const groups = new Map<string, AutopilotDevice[]>();
+    for (const device of sortedDevices) {
+      const tag = device.groupTag || "(No Group Tag)";
+      if (!groups.has(tag)) groups.set(tag, []);
+      groups.get(tag)!.push(device);
+    }
+    const sorted = [...groups.entries()].sort(([a], [b]) => {
+      if (a === "(No Group Tag)") return 1;
+      if (b === "(No Group Tag)") return -1;
+      return a.localeCompare(b);
+    });
+    return sorted;
+  }, [sortedDevices]);
+
+  const toggleGroup = (tag: string) => {
+    setExpandedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(tag)) next.delete(tag);
+      else next.add(tag);
+      return next;
+    });
+  };
+
+  const toggleChecked = useCallback((deviceId: string) => {
+    setCheckedDevices((prev) => {
+      const next = new Set(prev);
+      if (next.has(deviceId)) next.delete(deviceId);
+      else next.add(deviceId);
+      return next;
+    });
+  }, []);
+
+  const clearChecked = () => setCheckedDevices(new Set());
+
+  const selectAllVisible = () => {
+    setCheckedDevices(new Set(sortedDevices.map((d) => d.id)));
+  };
+
+  const handleDeleteDevice = async (device: AutopilotDevice) => {
+    if (!(await confirm(`Delete Autopilot device "${device.serialNumber || device.id}"? This cannot be undone.`)))
+      return;
+    showToast(`Deleting ${device.serialNumber || device.id}...`, "info");
+    try {
+      await invoke("delete_autopilot_device", { deviceId: device.id });
+      setAutopilotDevices((prev) => prev.filter((d) => d.id !== device.id));
+      if (selectedDevice?.id === device.id) setSelectedDevice(null);
+      showToast(`Deleted ${device.serialNumber || device.id}`, "success");
+    } catch (e) {
+      showToast(`Delete failed: ${e}`, "error");
+    }
+  };
+
+  const handleBulkDelete = async () => {
+    const count = checkedDevices.size;
+    if (count === 0) return;
+    if (!(await confirm(`Delete ${count} Autopilot device(s)? This cannot be undone.`))) return;
+    if (count > 100) {
+      if (!(await confirm(`You are about to delete ${count} devices. This is a large operation. Are you absolutely sure?`)))
+        return;
+    }
+    let ok = 0,
+      fail = 0;
+    const ids = [...checkedDevices];
+    for (let i = 0; i < ids.length; i++) {
+      updateProgress("Deleting", i + 1, ids.length);
+      try {
+        await invoke("delete_autopilot_device", { deviceId: ids[i] });
+        ok++;
+      } catch {
+        fail++;
+      }
+    }
+    setAutopilotDevices((prev) => prev.filter((d) => !checkedDevices.has(d.id)));
+    if (selectedDevice && checkedDevices.has(selectedDevice.id)) setSelectedDevice(null);
+    clearChecked();
+    showToast(`Delete: ${ok} succeeded, ${fail} failed`, ok > 0 ? "success" : "error");
+  };
+
+  const handleUpdateGroupTag = async (deviceId: string, groupTag: string) => {
+    showToast("Updating group tag...", "info");
+    try {
+      await invoke("update_autopilot_group_tag", { deviceId, groupTag });
+      setAutopilotDevices((prev) =>
+        prev.map((d) => (d.id === deviceId ? { ...d, groupTag: groupTag || null } : d))
+      );
+      if (selectedDevice?.id === deviceId) {
+        setSelectedDevice((prev) => (prev ? { ...prev, groupTag: groupTag || null } : null));
+      }
+      setEditingGroupTag(null);
+      showToast("Group tag updated", "success");
+    } catch (e) {
+      showToast(`Update failed: ${e}`, "error");
+    }
+  };
+
+  const handleBulkGroupTag = async (groupTag: string) => {
+    const count = checkedDevices.size;
+    if (count === 0) return;
+    if (!(await confirm(`Set group tag to "${groupTag}" on ${count} device(s)?`))) return;
+    if (count > 100) {
+      if (!(await confirm(`You are about to update ${count} devices. Are you absolutely sure?`)))
+        return;
+    }
+    setBulkGroupTag(null);
+    let ok = 0,
+      fail = 0;
+    const ids = [...checkedDevices];
+    for (let i = 0; i < ids.length; i++) {
+      updateProgress("Updating group tag", i + 1, ids.length);
+      try {
+        await invoke("update_autopilot_group_tag", { deviceId: ids[i], groupTag });
+        ok++;
+      } catch {
+        fail++;
+      }
+    }
+    setAutopilotDevices((prev) =>
+      prev.map((d) => (checkedDevices.has(d.id) ? { ...d, groupTag: groupTag || null } : d))
+    );
+    clearChecked();
+    showToast(`Group tag: ${ok} succeeded, ${fail} failed`, ok > 0 ? "success" : "error");
+  };
+
+  const handleImportCsv = async () => {
+    try {
+      const filePath = await open({
+        title: "Import Autopilot Devices (CSV)",
+        filters: [{ name: "CSV", extensions: ["csv"] }],
+        multiple: false,
+      });
+      if (!filePath) return;
+
+      const contents = await readTextFile(filePath as string);
+      const lines = contents.split(/\r?\n/).filter((l) => l.trim().length > 0);
+      if (lines.length < 2) {
+        showToast("CSV file must have a header row and at least one device", "error");
+        return;
+      }
+
+      // Parse header to find column indices
+      const header = lines[0].split(",").map((h) => h.trim().toLowerCase().replace(/['"]/g, ""));
+      const serialIdx = header.findIndex(
+        (h) => h.includes("serial") && h.includes("number")
+      );
+      const hashIdx = header.findIndex(
+        (h) => h.includes("hardware") && h.includes("hash")
+      );
+      const productIdx = header.findIndex(
+        (h) => h.includes("product") && h.includes("id")
+      );
+      const groupTagIdx = header.findIndex((h) => h.includes("group") && h.includes("tag"));
+      const userIdx = header.findIndex(
+        (h) => h.includes("assigned") && h.includes("user")
+      );
+
+      if (hashIdx === -1) {
+        showToast("CSV must have a 'Hardware Hash' column", "error");
+        return;
+      }
+
+      const entries: AutopilotImportEntry[] = [];
+      for (let i = 1; i < lines.length; i++) {
+        const cols = parseCsvLine(lines[i]);
+        const hash = cols[hashIdx]?.trim();
+        if (!hash) continue;
+
+        entries.push({
+          hardwareIdentifier: hash,
+          serialNumber: serialIdx >= 0 ? cols[serialIdx]?.trim() || null : null,
+          productKey: productIdx >= 0 ? cols[productIdx]?.trim() || null : null,
+          groupTag: groupTagIdx >= 0 ? cols[groupTagIdx]?.trim() || null : null,
+          assignedUserPrincipalName: userIdx >= 0 ? cols[userIdx]?.trim() || null : null,
+        });
+      }
+
+      if (entries.length === 0) {
+        showToast("No valid entries found in CSV", "error");
+        return;
+      }
+
+      if (!(await confirm(`Import ${entries.length} device(s) into Autopilot?`))) return;
+
+      showToast(`Importing ${entries.length} device(s)...`, "info");
+
+      const results = await invoke<AutopilotImportResult[]>("import_autopilot_devices", {
+        entries,
+      });
+
+      const succeeded = results.filter(
+        (r) => r.state?.deviceImportStatus !== "error"
+      ).length;
+      const failed = results.length - succeeded;
+
+      showToast(
+        `Import: ${succeeded} succeeded, ${failed} failed`,
+        succeeded > 0 ? "success" : "error"
+      );
+
+      // Reload the device list
+      loadAutopilotDevices();
+    } catch (e) {
+      showToast(`Import failed: ${e}`, "error");
+    }
+  };
+
+  // Simple CSV line parser that handles quoted fields
+  const parseCsvLine = (line: string): string[] => {
+    const result: string[] = [];
+    let current = "";
+    let inQuotes = false;
+    for (let i = 0; i < line.length; i++) {
+      const ch = line[i];
+      if (ch === '"') {
+        if (inQuotes && i + 1 < line.length && line[i + 1] === '"') {
+          current += '"';
+          i++;
+        } else {
+          inQuotes = !inQuotes;
+        }
+      } else if (ch === "," && !inQuotes) {
+        result.push(current);
+        current = "";
+      } else {
+        current += ch;
+      }
+    }
+    result.push(current);
+    return result;
+  };
+
+  const enrollmentBadge = (state: string | null) => {
+    const s = (state || "unknown").toLowerCase();
+    if (s === "enrolled") return <span className="badge compliant">Enrolled</span>;
+    if (s === "notcontacted") return <span className="badge unknown">Not Contacted</span>;
+    return <span className="badge unknown">{state || "Unknown"}</span>;
+  };
+
+  // Initial loading screen
+  if (loading && autopilotDevices.length === 0) {
+    return (
+      <div className="autopilot-loading">
+        <span className="spinner dark large" />
+        <p>Loading Autopilot devices...</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {/* Bulk action bar */}
+      {checkedDevices.size > 0 && (
+        <div className="bulk-bar">
+          <div className="bulk-left">
+            <button className="bulk-close" onClick={clearChecked} title="Clear selection">
+              <Icon path={mdiClose} size={0.6} />
+            </button>
+            <span className="bulk-info">{checkedDevices.size} selected</span>
+          </div>
+          <div className="bulk-actions-group">
+            <button className="bulk-btn" onClick={handleBulkDelete}>
+              <Icon path={mdiDelete} size={0.65} />
+              <span>Delete</span>
+            </button>
+            <div className="bulk-divider" />
+            <div className="bulk-list-dropdown">
+              <button
+                className="bulk-btn"
+                onClick={() => setBulkGroupTag(bulkGroupTag !== null ? null : "")}
+              >
+                <Icon path={mdiTag} size={0.65} />
+                <span>Set group tag</span>
+              </button>
+              {bulkGroupTag !== null && (
+                <div className="bulk-list-menu">
+                  <div className="bulk-list-menu-new">
+                    <input
+                      type="text"
+                      placeholder="Group tag..."
+                      value={bulkGroupTag}
+                      onChange={(e) => setBulkGroupTag(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") handleBulkGroupTag(bulkGroupTag);
+                        if (e.key === "Escape") setBulkGroupTag(null);
+                      }}
+                      autoFocus
+                    />
+                    <button
+                      className="btn-primary btn-small"
+                      onClick={() => handleBulkGroupTag(bulkGroupTag)}
+                    >
+                      Apply
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div className="main-content">
+        {/* Sidebar with autopilot device list */}
+        <div className="sidebar">
+          <div className="autopilot-sidebar-header">
+            <button
+              className="btn-secondary btn-small"
+              onClick={handleImportCsv}
+              title="Import devices from CSV"
+            >
+              <Icon path={mdiImport} size={0.6} />
+              Import CSV
+            </button>
+          </div>
+
+          <div className="search-box">
+            <input
+              type="text"
+              placeholder="Search Autopilot devices..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+            />
+            <div className="search-actions">
+              <button
+                className="search-action-btn"
+                onClick={
+                  checkedDevices.size === sortedDevices.length && sortedDevices.length > 0
+                    ? clearChecked
+                    : selectAllVisible
+                }
+                title={
+                  checkedDevices.size === sortedDevices.length && sortedDevices.length > 0
+                    ? "Deselect all"
+                    : "Select all"
+                }
+                disabled={sortedDevices.length === 0}
+              >
+                <Icon
+                  path={checkedDevices.size === sortedDevices.length && sortedDevices.length > 0 ? mdiSelectionOff : mdiSelectAll}
+                  size={0.6}
+                />
+                <span>
+                  {checkedDevices.size === sortedDevices.length && sortedDevices.length > 0
+                    ? "Deselect all"
+                    : "Select all"}
+                </span>
+              </button>
+              <span className="search-count">{sortedDevices.length} devices</span>
+            </div>
+          </div>
+
+          <div className="device-list">
+            {groupedDevices.map(([tag, tagDevices]) => (
+              <div key={tag} className="device-group">
+                <div className="device-group-header" onClick={() => toggleGroup(tag)}>
+                  <Icon
+                    path={expandedGroups.has(tag) ? mdiChevronDown : mdiChevronRight}
+                    size={0.65}
+                    className="group-chevron"
+                  />
+                  <Icon path={mdiTag} size={0.55} className="group-tag-icon" />
+                  <span className="group-name">{tag}</span>
+                  <span className="group-count">{tagDevices.length}</span>
+                </div>
+                {expandedGroups.has(tag) &&
+                  tagDevices.map((device) => {
+                    const isSelected = selectedDevice?.id === device.id;
+                    const isChecked = checkedDevices.has(device.id);
+                    return (
+                      <div
+                        key={device.id}
+                        className={`device-item${isSelected ? " selected" : ""}${isChecked ? " checked" : ""}`}
+                        onClick={() => setSelectedDevice(device)}
+                      >
+                        <div className="device-item-content">
+                          <div
+                            className="device-icon-wrapper"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              toggleChecked(device.id);
+                            }}
+                          >
+                            <Icon path={mdiLaptop} size={0.85} className="device-os-icon" />
+                            <Icon
+                              path={isChecked ? mdiCheckboxMarked : mdiCheckboxBlankOutline}
+                              size={0.85}
+                              className="device-checkbox-icon"
+                            />
+                          </div>
+                          <div className="device-item-text">
+                            <div className="device-name">
+                              {device.serialNumber || device.id.substring(0, 8) + "..."}
+                            </div>
+                            <div className="device-sync">
+                              {device.model
+                                ? `${device.manufacturer || ""} ${device.model}`.trim()
+                                : "Unknown model"}
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })}
+              </div>
+            ))}
+            {sortedDevices.length === 0 && !loading && (
+              <div className="empty-state">
+                {autopilotDevices.length === 0 ? "No Autopilot devices loaded" : "No matches"}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Detail panel */}
+        <div className="detail-panel">
+          {selectedDevice ? (
+            <div className="device-detail">
+              <div className="action-toolbar">
+                <button
+                  className="toolbar-btn"
+                  onClick={() =>
+                    setEditingGroupTag({
+                      id: selectedDevice.id,
+                      value: selectedDevice.groupTag || "",
+                    })
+                  }
+                >
+                  <Icon path={mdiTag} size={0.65} />
+                  <span>Set group tag</span>
+                </button>
+                <div className="toolbar-divider" />
+                <button
+                  className="toolbar-btn toolbar-btn-danger"
+                  onClick={() => handleDeleteDevice(selectedDevice)}
+                >
+                  <Icon path={mdiDelete} size={0.65} />
+                  <span>Delete</span>
+                </button>
+              </div>
+
+              <div className="device-detail-body">
+                <h2 className="device-detail-title">
+                  <Icon path={mdiLaptop} size={1} className="device-detail-icon" />
+                  {selectedDevice.serialNumber || "Autopilot Device"}
+                </h2>
+
+                <div className="detail-grid">
+                  <span className="detail-label">Serial Number</span>
+                  <span className="detail-value">{selectedDevice.serialNumber || "N/A"}</span>
+
+                  <span className="detail-label">Manufacturer</span>
+                  <span className="detail-value">{selectedDevice.manufacturer || "N/A"}</span>
+
+                  <span className="detail-label">Model</span>
+                  <span className="detail-value">{selectedDevice.model || "N/A"}</span>
+
+                  <span className="detail-label">Group Tag</span>
+                  <span className="detail-value">
+                    {editingGroupTag?.id === selectedDevice.id ? (
+                      <span className="group-tag-edit">
+                        <input
+                          type="text"
+                          value={editingGroupTag.value}
+                          onChange={(e) =>
+                            setEditingGroupTag({ ...editingGroupTag, value: e.target.value })
+                          }
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter")
+                              handleUpdateGroupTag(editingGroupTag.id, editingGroupTag.value);
+                            if (e.key === "Escape") setEditingGroupTag(null);
+                          }}
+                          autoFocus
+                          placeholder="Enter group tag..."
+                        />
+                        <button
+                          className="btn-primary btn-small"
+                          onClick={() =>
+                            handleUpdateGroupTag(editingGroupTag.id, editingGroupTag.value)
+                          }
+                        >
+                          Save
+                        </button>
+                        <button
+                          className="btn-secondary btn-small"
+                          onClick={() => setEditingGroupTag(null)}
+                        >
+                          Cancel
+                        </button>
+                      </span>
+                    ) : (
+                      <span
+                        className="group-tag-display"
+                        onClick={() =>
+                          setEditingGroupTag({
+                            id: selectedDevice.id,
+                            value: selectedDevice.groupTag || "",
+                          })
+                        }
+                        title="Click to edit"
+                      >
+                        {selectedDevice.groupTag || "(none)"}
+                      </span>
+                    )}
+                  </span>
+
+                  <span className="detail-label">Enrollment</span>
+                  <span className="detail-value">
+                    {enrollmentBadge(selectedDevice.enrollmentState)}
+                  </span>
+
+                  <span className="detail-label">User</span>
+                  <span className="detail-value">
+                    {selectedDevice.userPrincipalName ||
+                      selectedDevice.addressableUserName ||
+                      "N/A"}
+                  </span>
+
+                  <span className="detail-label">Last Contacted</span>
+                  <span className="detail-value">
+                    {formatDate(selectedDevice.lastContactedDateTime)}
+                  </span>
+
+                  <span className="detail-label">Azure AD Device ID</span>
+                  <span className="detail-value">
+                    {selectedDevice.azureActiveDirectoryDeviceId ||
+                      selectedDevice.azureAdDeviceId ||
+                      "N/A"}
+                  </span>
+
+                  <span className="detail-label">Managed Device ID</span>
+                  <span className="detail-value">{selectedDevice.managedDeviceId || "N/A"}</span>
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="no-selection">Select an Autopilot device to view details</div>
+          )}
+        </div>
+      </div>
+
+      {/* Group tag edit modal - for inline editing */}
+      {editingGroupTag && !selectedDevice && (
+        <div className="modal-overlay" onClick={() => setEditingGroupTag(null)}>
+          <div className="modal" onClick={(e) => e.stopPropagation()}>
+            <h3>Set Group Tag</h3>
+            <div className="modal-list">
+              <input
+                type="text"
+                value={editingGroupTag.value}
+                onChange={(e) => setEditingGroupTag({ ...editingGroupTag, value: e.target.value })}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter")
+                    handleUpdateGroupTag(editingGroupTag.id, editingGroupTag.value);
+                }}
+                placeholder="Enter group tag..."
+                autoFocus
+              />
+            </div>
+            <div className="modal-actions">
+              <button className="btn-secondary" onClick={() => setEditingGroupTag(null)}>
+                Cancel
+              </button>
+              <button
+                className="btn-primary"
+                onClick={() => handleUpdateGroupTag(editingGroupTag.id, editingGroupTag.value)}
+              >
+                Save
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+export default AutopilotView;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -39,6 +39,44 @@ export interface Toast {
   progress?: { current: number; total: number };
 }
 
+/** Autopilot device from Graph API */
+export interface AutopilotDevice {
+  id: string;
+  groupTag: string | null;
+  serialNumber: string | null;
+  productKey: string | null;
+  manufacturer: string | null;
+  model: string | null;
+  enrollmentState: string | null;
+  lastContactedDateTime: string | null;
+  addressableUserName: string | null;
+  userPrincipalName: string | null;
+  managedDeviceId: string | null;
+  azureActiveDirectoryDeviceId: string | null;
+  azureAdDeviceId: string | null;
+  displayName: string | null;
+}
+
+/** Entry for importing an Autopilot device */
+export interface AutopilotImportEntry {
+  serialNumber: string | null;
+  hardwareIdentifier: string;
+  productKey: string | null;
+  groupTag: string | null;
+  assignedUserPrincipalName: string | null;
+}
+
+/** Result of an Autopilot device import */
+export interface AutopilotImportResult {
+  id: string;
+  serialNumber: string | null;
+  state: {
+    deviceImportStatus: string | null;
+    deviceErrorCode: number | null;
+    deviceErrorName: string | null;
+  } | null;
+}
+
 /** OS tab categories */
 export const OS_TABS = ["All", "Windows", "macOS", "iOS", "Android", "Linux"] as const;
 export type OsTab = (typeof OS_TABS)[number];


### PR DESCRIPTION
Add a new Autopilot view accessible via a view switcher in the header. Features include:
- List all Windows Autopilot devices with search and grouping by tag
- Delete Autopilot devices (single and bulk)
- Assign/update group tags (single and bulk)
- Import devices from CSV (Intune portal format with Hardware Hash)
- Detail panel showing serial number, manufacturer, model, enrollment state, group tag (click-to-edit), and more

Backend adds Graph API endpoints for windowsAutopilotDeviceIdentities and importedWindowsAutopilotDeviceIdentities.

Closes #2