### PR TITLE
fix: search box visibility in dark mode

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1555,6 +1555,11 @@ button {
     color: #f5f5f7;
   }
 
+  .search-box input:focus {
+    background: #2d2d2f;
+    border-color: #0071e3;
+  }
+
   .device-item:hover {
     background: #3a3a3c;
   }


### PR DESCRIPTION
Fix search box text being illegible when focused in dark mode. The focus state set a white background but text remained white.

Fixes #6

Generated with [Claude Code](https://claude.ai/code)