### PR TITLE
Fix import CSV icon alignment in autopilot sidebar

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1492,6 +1492,12 @@ button {
   gap: 8px;
 }
 
+.autopilot-sidebar-header button {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .group-tag-icon {
   color: #86868b;
   flex-shrink: 0;


### PR DESCRIPTION
Fix the import CSV button icon in the autopilot sidebar header so it is vertically centered with the button text.

Added `display: inline-flex`, `align-items: center`, and `gap: 4px` to `.autopilot-sidebar-header button`.

Fixes #8

Generated with [Claude Code](https://claude.ai/code)