### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "intune-app"
-version = "0.1.0"
+version = "0.2.0"
 description = "Intune Device Management"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Intune Device Manager",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "identifier": "com.jacob.intune-device-manager",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Bump version from 0.1.0 to 0.2.0 in tauri.conf.json and Cargo.toml.

Closes #10

Generated with [Claude Code](https://claude.ai/code)