### PR TITLE
feat: add typed confirmation for bulk destructive actions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ npm run tauri build   # production
 - Custom device lists and folders stored in localStorage
 - Client secrets stored in OS keychain (macOS Keychain / Windows Credential Manager)
 - Groups collapsed by default, bulk actions require double confirmation for >100 devices
+- Bulk destructive actions (e.g. delete) must require the user to type a confirmation phrase: "I really want to delete <n> devices" where <n> is the number of selected devices. Use a modal with a text input, not a native confirm dialog. The delete button must stay disabled until the phrase matches exactly. Apply this pattern to any new bulk destructive action.
 
 ## Releasing
 1. Bump version in `src-tauri/tauri.conf.json` and `src-tauri/Cargo.toml`

--- a/src/App.css
+++ b/src/App.css
@@ -1313,6 +1313,50 @@ button {
   gap: 8px;
 }
 
+/* Destructive confirmation */
+.destructive-confirm-text {
+  font-size: 13px;
+  margin-bottom: 12px;
+  line-height: 1.5;
+}
+
+.destructive-confirm-phrase {
+  color: #e53935;
+  font-family: monospace;
+  font-size: 12px;
+}
+
+.destructive-confirm-input {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid #d2d2d7;
+  border-radius: 6px;
+  font-size: 13px;
+  margin-bottom: 16px;
+}
+
+.destructive-confirm-input:focus {
+  outline: none;
+  border-color: #e53935;
+  box-shadow: 0 0 0 2px rgba(229, 57, 53, 0.15);
+}
+
+.btn-danger {
+  padding: 8px 16px;
+  border: none;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  background: #e53935;
+  color: #fff;
+}
+
+.btn-danger:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
 /* Status toast */
 .toast {
   position: fixed;
@@ -1583,6 +1627,16 @@ button {
 
   .modal {
     background: #2d2d2f;
+  }
+
+  .destructive-confirm-input {
+    background: #1c1c1e;
+    border-color: #424245;
+    color: #f5f5f7;
+  }
+
+  .destructive-confirm-input:focus {
+    border-color: #e53935;
   }
 
   .script-item {

--- a/src/components/AutopilotView.tsx
+++ b/src/components/AutopilotView.tsx
@@ -35,6 +35,7 @@ function AutopilotView({ showToast, updateProgress, isActive }: AutopilotViewPro
   const [editingGroupTag, setEditingGroupTag] = useState<{ id: string; value: string } | null>(null);
   const [bulkGroupTag, setBulkGroupTag] = useState<string | null>(null);
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
+  const [deleteConfirm, setDeleteConfirm] = useState<{ count: number; input: string } | null>(null);
   const wasActive = useRef(false);
 
   const loadAutopilotDevices = useCallback(async () => {
@@ -160,14 +161,16 @@ function AutopilotView({ showToast, updateProgress, isActive }: AutopilotViewPro
     }
   };
 
-  const handleBulkDelete = async () => {
+  const promptBulkDelete = () => {
     const count = checkedDevices.size;
     if (count === 0) return;
-    if (!(await confirm(`Delete ${count} Autopilot device(s)? This cannot be undone.`))) return;
-    if (count > 100) {
-      if (!(await confirm(`You are about to delete ${count} devices. This is a large operation. Are you absolutely sure?`)))
-        return;
-    }
+    setDeleteConfirm({ count, input: "" });
+  };
+
+  const executeBulkDelete = async () => {
+    if (!deleteConfirm) return;
+    const count = deleteConfirm.count;
+    setDeleteConfirm(null);
     let ok = 0,
       fail = 0;
     const ids = [...checkedDevices];
@@ -367,7 +370,7 @@ function AutopilotView({ showToast, updateProgress, isActive }: AutopilotViewPro
             <span className="bulk-info">{checkedDevices.size} selected</span>
           </div>
           <div className="bulk-actions-group">
-            <button className="bulk-btn" onClick={handleBulkDelete}>
+            <button className="bulk-btn" onClick={promptBulkDelete}>
               <Icon path={mdiDelete} size={0.65} />
               <span>Delete</span>
             </button>
@@ -674,6 +677,46 @@ function AutopilotView({ showToast, updateProgress, isActive }: AutopilotViewPro
                 onClick={() => handleUpdateGroupTag(editingGroupTag.id, editingGroupTag.value)}
               >
                 Save
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Typed confirmation modal for bulk delete */}
+      {deleteConfirm && (
+        <div className="modal-overlay" onClick={() => setDeleteConfirm(null)}>
+          <div className="modal" onClick={(e) => e.stopPropagation()}>
+            <h3>Confirm Bulk Delete</h3>
+            <p className="destructive-confirm-text">
+              You are about to delete <strong>{deleteConfirm.count}</strong> Autopilot device(s). This cannot be undone.
+            </p>
+            <p className="destructive-confirm-text">
+              Type <strong className="destructive-confirm-phrase">I really want to delete {deleteConfirm.count} devices</strong> to confirm:
+            </p>
+            <input
+              className="destructive-confirm-input"
+              type="text"
+              value={deleteConfirm.input}
+              onChange={(e) => setDeleteConfirm({ ...deleteConfirm, input: e.target.value })}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && deleteConfirm.input === `I really want to delete ${deleteConfirm.count} devices`)
+                  executeBulkDelete();
+                if (e.key === "Escape") setDeleteConfirm(null);
+              }}
+              placeholder={`I really want to delete ${deleteConfirm.count} devices`}
+              autoFocus
+            />
+            <div className="modal-actions">
+              <button className="btn-secondary" onClick={() => setDeleteConfirm(null)}>
+                Cancel
+              </button>
+              <button
+                className="btn-danger"
+                disabled={deleteConfirm.input !== `I really want to delete ${deleteConfirm.count} devices`}
+                onClick={executeBulkDelete}
+              >
+                Delete {deleteConfirm.count} devices
               </button>
             </div>
           </div>


### PR DESCRIPTION
Replace native confirm dialog with a modal requiring users to type "I really want to delete <n> devices" before bulk delete proceeds. The delete button stays disabled until the phrase matches exactly.

Closes #14

Generated with [Claude Code](https://claude.ai/code)