### PR TITLE
fix: remove unused variable causing build failure

### DIFF
--- a/src/components/AutopilotView.tsx
+++ b/src/components/AutopilotView.tsx
@@ -169,7 +169,6 @@ function AutopilotView({ showToast, updateProgress, isActive }: AutopilotViewPro
 
   const executeBulkDelete = async () => {
     if (!deleteConfirm) return;
-    const count = deleteConfirm.count;
     setDeleteConfirm(null);
     let ok = 0,
       fail = 0;


### PR DESCRIPTION
Removes the unused `count` variable in `AutopilotView.tsx` that was causing TypeScript build failures across all platforms.

Closes #16

Generated with [Claude Code](https://claude.ai/code)