### PR TITLE
feat: show filter list memberships on device sidebar

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1032,6 +1032,32 @@ button {
   text-overflow: ellipsis;
 }
 
+.device-list-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px;
+  margin-top: 2px;
+}
+
+.device-list-tag {
+  font-size: 10px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.6);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 120px;
+}
+
+@media (prefers-color-scheme: light) {
+  .device-list-tag {
+    background: rgba(0, 0, 0, 0.06);
+    color: rgba(0, 0, 0, 0.55);
+  }
+}
+
 /* Action toolbar (Intune-style) */
 .action-toolbar {
   display: flex;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -824,6 +824,18 @@ function App() {
     return counts;
   }, [deviceLists, devices, activeTab]);
 
+  // Map device ID -> list names the device belongs to
+  const deviceListMemberships = useMemo(() => {
+    const map: Record<string, string[]> = {};
+    for (const list of deviceLists) {
+      for (const deviceId of list.deviceIds) {
+        if (!map[deviceId]) map[deviceId] = [];
+        map[deviceId].push(list.name);
+      }
+    }
+    return map;
+  }, [deviceLists]);
+
   const filteredDevices = useMemo(() => {
     let result = devices;
 
@@ -1456,6 +1468,7 @@ function App() {
                       device={device}
                       isSelected={selectedDevice?.id === device.id}
                       isChecked={checkedDevices.has(device.id)}
+                      listNames={deviceListMemberships[device.id]}
                       onSelect={setSelectedDevice}
                       onToggleCheck={toggleChecked}
                     />

--- a/src/components/DeviceItem.tsx
+++ b/src/components/DeviceItem.tsx
@@ -8,12 +8,13 @@ interface DeviceItemProps {
   device: DeviceInfo;
   isSelected: boolean;
   isChecked: boolean;
+  listNames?: string[];
   onSelect: (device: DeviceInfo) => void;
   onToggleCheck: (deviceId: string) => void;
 }
 
 const DeviceItem = memo<DeviceItemProps>(
-  ({ device, isSelected, isChecked, onSelect, onToggleCheck }) => {
+  ({ device, isSelected, isChecked, listNames, onSelect, onToggleCheck }) => {
     const isMissing = device.deviceName.startsWith("[Not found]");
     const className = `device-item${isSelected ? " selected" : ""}${isChecked ? " checked" : ""}${isMissing ? " missing" : ""}`;
 
@@ -43,6 +44,13 @@ const DeviceItem = memo<DeviceItemProps>(
             <div className="device-sync">
               {isMissing ? "Device not found in Intune" : relativeTime(device.lastSyncDateTime)}
             </div>
+            {listNames && listNames.length > 0 && (
+              <div className="device-list-tags">
+                {listNames.map((name) => (
+                  <span key={name} className="device-list-tag">{name}</span>
+                ))}
+              </div>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Closes #20

Devices that belong to custom lists now display small tags below the sync time in the sidebar, making it easy to see which lists a device is part of at a glance.

Generated with [Claude Code](https://claude.ai/code)