### PR TITLE
feat: Refresh device info in background on selection

### DIFF
--- a/src-tauri/src/graph.rs
+++ b/src-tauri/src/graph.rs
@@ -258,6 +258,28 @@ impl<'a> GraphClient<'a> {
         self.get_all_pages::<DeviceInfo>(&initial_url).await
     }
 
+    pub async fn get_managed_device(&self, device_id: &str) -> Result<DeviceInfo, AppError> {
+        validate_id(device_id, "device_id")?;
+        let url = format!(
+            "{}/managedDevices/{}?$select=id,deviceName,userPrincipalName,operatingSystem,osVersion,complianceState,lastSyncDateTime,managementState",
+            GRAPH_BASE, device_id
+        );
+
+        let resp = self.request_with_retry(|| {
+            self.client
+                .get(&url)
+                .bearer_auth(&self.access_token)
+        }).await?;
+
+        if !resp.status().is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(AppError::Graph(body));
+        }
+
+        let device: DeviceInfo = resp.json().await?;
+        Ok(device)
+    }
+
     pub async fn sync_device(&self, device_id: &str) -> Result<(), AppError> {
         validate_id(device_id, "device_id")?;
         let url = format!("{}/managedDevices/{}/syncDevice", GRAPH_BASE, device_id);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -96,6 +96,13 @@ async fn get_devices(state: State<'_>) -> Result<Vec<DeviceInfo>, AppError> {
 }
 
 #[tauri::command]
+async fn get_device(state: State<'_>, device_id: String) -> Result<DeviceInfo, AppError> {
+    let (http_client, token) = get_client_and_token(&state).await?;
+    let client = GraphClient::new(&http_client, token);
+    client.get_managed_device(&device_id).await
+}
+
+#[tauri::command]
 async fn sync_device(state: State<'_>, device_id: String) -> Result<(), AppError> {
     let (http_client, token) = get_client_and_token(&state).await?;
     let client = GraphClient::new(&http_client, token);
@@ -196,6 +203,7 @@ pub fn run() {
             login,
             logout,
             get_devices,
+            get_device,
             sync_device,
             restart_device,
             run_remediation,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -189,6 +189,25 @@ function App() {
     }
   };
 
+  const handleSelectDevice = useCallback((device: DeviceInfo) => {
+    setSelectedDevice(device);
+    // Fetch updated device info in the background
+    invoke<DeviceInfo>("get_device", { deviceId: device.id })
+      .then((updated) => {
+        // Update the device in the devices list
+        setDevices((prev) =>
+          prev.map((d) => (d.id === updated.id ? updated : d))
+        );
+        // Update selectedDevice only if this device is still selected
+        setSelectedDevice((prev) =>
+          prev?.id === updated.id ? updated : prev
+        );
+      })
+      .catch(() => {
+        // Silently ignore — stale data is still shown
+      });
+  }, []);
+
   const handleSync = async (device: DeviceInfo) => {
     showToast(`Syncing ${device.deviceName}...`, "info");
     try {
@@ -1161,7 +1180,7 @@ function App() {
             setActiveView("devices");
             setActiveTab("All");
             setActiveList(null);
-            setSelectedDevice(device);
+            handleSelectDevice(device);
           }
         }} />
       </div>
@@ -1469,7 +1488,7 @@ function App() {
                       isSelected={selectedDevice?.id === device.id}
                       isChecked={checkedDevices.has(device.id)}
                       listNames={deviceListMemberships[device.id]}
-                      onSelect={setSelectedDevice}
+                      onSelect={handleSelectDevice}
                       onToggleCheck={toggleChecked}
                     />
                   ))}


### PR DESCRIPTION
When a device is selected from the list, fetch updated device info from the Graph API in the background and update the UI once received.

Closes #22

Generated with [Claude Code](https://claude.ai/code)